### PR TITLE
add the missing `sphinx.configuration` key

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,6 @@ python:
     - method: pip
       path: project
 sphinx:
+  configuration: project/docs/conf.py
   builder: dirhtml
   fail_on_warning: false


### PR DESCRIPTION
See:
https://app.readthedocs.org/projects/flask-zh/builds/28528619/ 
and:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/